### PR TITLE
Remora Core PWM Module

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -17,11 +17,8 @@ namespace Config {
     constexpr uint32_t joints = 8;                 // Number of joints
     constexpr uint32_t variables = 6;              // Number of command values
 
-    #ifdef ETH_CTRL
-    constexpr uint32_t pruData = 0x64617461;       // "dat_" SPI payload for remora-eth-3.0 component
-    #else
-    constexpr uint32_t pruData = 0x64617400;       // "dat_" SPI payload for latest remora-core SPI component
-    #endif
+
+    constexpr uint32_t pruData = 0x64617461;       // "data" SPI payload
     constexpr uint32_t pruRead = 0x72656164;       // "read" SPI payload
     constexpr uint32_t pruWrite = 0x77726974;      // "writ" SPI payload
     constexpr uint32_t pruEstop = 0x65737470;      // "estp" SPI payload

--- a/configuration.h
+++ b/configuration.h
@@ -17,8 +17,11 @@ namespace Config {
     constexpr uint32_t joints = 8;                 // Number of joints
     constexpr uint32_t variables = 6;              // Number of command values
 
-
-    constexpr uint32_t pruData = 0x64617461;       // "data" SPI payload
+    #ifdef ETH_CTRL
+    constexpr uint32_t pruData = 0x64617461;       // "dat_" SPI payload for remora-eth-3.0 component
+    #else
+    constexpr uint32_t pruData = 0x64617400;       // "dat_" SPI payload for latest remora-core SPI component
+    #endif
     constexpr uint32_t pruRead = 0x72656164;       // "read" SPI payload
     constexpr uint32_t pruWrite = 0x77726974;      // "writ" SPI payload
     constexpr uint32_t pruEstop = 0x65737470;      // "estp" SPI payload

--- a/modules/moduleFactory.cpp
+++ b/modules/moduleFactory.cpp
@@ -23,6 +23,8 @@ std::shared_ptr<Module> ModuleFactory::createModule(const char* _tname,
             return SigmaDelta::create(config, instance);
         } else if (strcmp(_mtype, "Temperature") == 0) {
             return Temperature::create(config, instance);
+        } else if (strcmp(_mtype, "PWM") == 0) {
+            return PWM::create(config, instance); 
         }
     } else if (strcmp(_tname, "On load") == 0) {
     	if (strcmp(_mtype, "TMC2208") == 0) {

--- a/modules/moduleList.h
+++ b/modules/moduleList.h
@@ -7,6 +7,7 @@
 #include "comms/commsHandler.h"
 #include "debug/debug.h"
 #include "digitalPin/digitalPin.h"
+#include "pwm/pwm.h"
 //#include "motorPower/motorPower.h"
 #include "resetPin/resetPin.h"
 #include "sigmaDelta/sigmaDelta.h"

--- a/modules/pwm/pwm.cpp
+++ b/modules/pwm/pwm.cpp
@@ -131,9 +131,6 @@ void PWM::recalculate_pulsewidth(void)
 
     if (pwmMax > 0 && (pwmPulseWidth / 100) * PWMMAX > pwmMax)
     {
-        //int capped_pwm = (pwmMax * 100) / PWMMAX;            
-        //pwmPulseWidth_us = (pwmPeriod_us * capped_pwm) / 100.0;
-        //pwmPulseWidth = capped_pwm;
         pwmPulseWidth = ((float)pwmMax / (float)PWMMAX) * 100;
     }
     hardware_PWM->change_pulsewidth(pwmPulseWidth);

--- a/modules/pwm/pwm.cpp
+++ b/modules/pwm/pwm.cpp
@@ -1,0 +1,145 @@
+#include "pwm.h"
+
+#define PID_PWM_MAX 256		// 8 bit resolution
+
+/***********************************************************************
+                MODULE CONFIGURATION AND CREATION FROM JSON     
+************************************************************************/
+std::shared_ptr<Module> PWM::create(const JsonObject& config, Remora* instance)
+{
+    PWM* new_pwm;
+    volatile float*     variable_pointers[Config::variables];
+
+    int sp = config["SP[i]"];  // when reading this value off the rx buffer, it will return the duty cycle.  
+    int pwmMax = config["PWM Max"];
+    const char* pin = config["PWM Pin"];
+    const char* hardware = config["Hardware PWM"];
+    const char* variable = config["Variable Freq"]; // by default all PWMs are variable.
+    int period_sp = config["Period SP[i]"];
+    int period_us = config["Period us"];
+    //const char* comment = config["Comment"];
+
+    //printf("\n%s\n",comment);
+    printf("Creating PWM at pin %s\n", pin);
+
+    /*printf("SP[i]: %d\n" // helps with a bit of debugging
+       "PWM Max: %d\n"
+       "PWM Pin: %s\n"
+       "Hardware PWM: %s\n"
+       "Variable Freq: %s\n"
+       "Period SP[i]: %d\n"
+       "Period us: %d\n",
+       sp, pwmMax, pin, hardware, variable, period_sp, period_us);*/
+   
+    // Create pointers for set point variables
+
+    variable_pointers[sp] = &instance->getRxData()->setPoint[sp];  // sp value will store the duty cycle.  
+    variable_pointers[period_sp] = &instance->getRxData()->setPoint[period_sp]; // todo - if this isn't enabled what does it do, see if we can check for errors. 
+    
+    if (!strcmp(hardware, "False")) // Software PWM
+    {
+        printf("Software PWM not yet supported\n");
+    }
+
+    bool variable_freq = !strcmp(variable, "True");
+    printf("PWM variable_freq = %d\n", variable_freq);
+
+    //new_pwm = new PWM(*variable_pointers[period_sp], *variable_pointers[sp], variable_freq, period_us, pwmMax, pin);   
+    //new_pwm->setPwmMax(pwmMax);
+    //servoThread->registerModule(new_pwm);
+	return std::make_unique<PWM>(*variable_pointers[period_sp], *variable_pointers[sp], variable_freq, period_us, pwmMax, pin);
+}
+
+/***********************************************************************
+                METHOD DEFINITIONS
+************************************************************************/
+
+PWM::PWM(volatile float &ptrPwmPeriod, volatile float &ptrPwmPulseWidth, bool variable_freq, int fixed_period_us, int pwmMax, std::string pin):
+    ptrPwmPeriod(&ptrPwmPeriod),
+    variable_freq(variable_freq),
+    ptrPwmPulseWidth(&ptrPwmPulseWidth),
+    pwmMax(pwmMax),
+    pin(pin)
+{
+    printf("Creating variable frequency Hardware PWM at pin %s\n", this->pin.c_str());
+
+    // set initial period and pulse width
+    if (this->variable_freq == true)
+    {
+        this->pwmPeriod_us = *(this->ptrPwmPeriod);
+    }
+    else 
+    {
+        this->pwmPeriod_us = fixed_period_us;    
+    }
+
+    if (this->pwmPeriod_us < 1)
+    {
+        this->pwmPeriod_us = DEFAULT_PWM_PERIOD;
+    }
+
+    this->pwmPulseWidth = *(this->ptrPwmPulseWidth);
+    this->pwmPulseWidth_us = (this->pwmPeriod_us * this->pwmPulseWidth) / 100.0;
+
+    setPwmMax(pwmMax);
+    
+    hardware_PWM = new HardwarePWM(this->pwmPeriod_us, this->pwmPulseWidth_us, this->pin); 
+}
+
+
+float PWM::getPwmPeriod(void) { return pwmPeriod_us; }
+float PWM::getPwmPulseWidth(void) { return pwmPulseWidth; }
+int PWM::getPwmPulseWidth_us(void) { return pwmPulseWidth_us; }
+void PWM::setPwmMax(int pwmMax) { this->pwmMax = pwmMax; }
+
+void PWM::update()
+{
+    if (this->variable_freq == true) 
+    {    
+        if (*(this->ptrPwmPeriod) != 0 && (*(this->ptrPwmPeriod) != this->pwmPeriod_us))
+        {
+            // PWM period has changed
+            this->pwmPeriod_us = *(this->ptrPwmPeriod);
+            this->hardware_PWM->change_period(this->pwmPeriod_us);
+
+            // force pulse width update by triggering the next if block.
+            this->pwmPulseWidth = 0;
+        }
+    }
+
+    if (*(this->ptrPwmPulseWidth) != this->pwmPulseWidth)
+    {
+        // PWM duty has changed
+        this->pwmPulseWidth = *(this->ptrPwmPulseWidth);
+
+        // clamp the percentage in case LinuxCNC sends something other than 0-100%
+        if (this->pwmPulseWidth <= 0) 
+        {
+            this->pwmPulseWidth = 0;
+        }
+        if (this->pwmPulseWidth > 100)
+        {
+            this->pwmPulseWidth = 100;
+        }
+
+        // Convert duty cycle % to us and update in hardware. 
+        // First check if the the duty cycle has exceeded PWM Max 1-256, and substitute the value if so.
+        // this->pwmPulseWidth and this->ptrPwmPulseWidth need to keep their values intact or else update method will run continuously.
+
+        if (this->pwmMax > 0 && (this->pwmPulseWidth / 100) * PWMMAX > this->pwmMax)
+        {
+            int capped_pwm = (this->pwmMax * 100) / PWMMAX;
+            this->pwmPulseWidth_us = (this->pwmPeriod_us * capped_pwm) / 100.0;
+        }
+        else 
+        {
+            this->pwmPulseWidth_us = (this->pwmPeriod_us * this->pwmPulseWidth) / 100.0;
+        }
+        this->hardware_PWM->change_pulsewidth(this->pwmPulseWidth_us);
+    } 
+}
+
+void PWM::slowUpdate()
+{
+	return;
+}

--- a/modules/pwm/pwm.cpp
+++ b/modules/pwm/pwm.cpp
@@ -7,7 +7,6 @@
 ************************************************************************/
 std::shared_ptr<Module> PWM::create(const JsonObject& config, Remora* instance)
 {
-    //PWM* new_pwm;
     volatile float*     variable_pointers[Config::variables];
 
     int sp = config["SP[i]"];  // when reading this value off the rx buffer, it will return the duty cycle.  
@@ -17,12 +16,11 @@ std::shared_ptr<Module> PWM::create(const JsonObject& config, Remora* instance)
     const char* variable = config["Variable Freq"]; // by default all PWMs are variable.
     int period_sp = config["Period SP[i]"];
     int period_us = config["Period us"];
-    //const char* comment = config["Comment"];
 
     //printf("\n%s\n",comment);
     printf("\nCreating PWM at pin %s\n", pin);
 
-    /*printf("SP[i]: %d\n" // helps with a bit of debugging
+    /*printf("SP[i]: %d\n" // Enable debug if needed
        "PWM Max: %d\n"
        "PWM Pin: %s\n"
        "Hardware PWM: %s\n"
@@ -42,11 +40,6 @@ std::shared_ptr<Module> PWM::create(const JsonObject& config, Remora* instance)
     }
 
     bool variable_freq = !strcmp(variable, "True");
-    //printf("PWM variable_freq = %d\n", variable_freq);
-
-    //new_pwm = new PWM(*variable_pointers[period_sp], *variable_pointers[sp], variable_freq, period_us, pwmMax, pin);   
-    //new_pwm->setPwmMax(pwmMax);
-    //servoThread->registerModule(new_pwm);
 	return std::make_unique<PWM>(*variable_pointers[period_sp], *variable_pointers[sp], variable_freq, period_us, pwmMax, pin);
 }
 
@@ -61,8 +54,6 @@ PWM::PWM(volatile float &_ptrPwmPeriod, volatile float &_ptrPwmPulseWidth, bool 
     pwmMax(_pwmMax),
     pin(_pin)
 {
-    //printf("Creating variable frequency Hardware PWM at pin %s\n", pin.c_str());
-
     // set initial period and pulse width
     if (variable_freq == true)
     {
@@ -79,18 +70,16 @@ PWM::PWM(volatile float &_ptrPwmPeriod, volatile float &_ptrPwmPulseWidth, bool 
     }
 
     pwmPulseWidth = *ptrPwmPulseWidth;
-    //pwmPulseWidth_us = (pwmPeriod_us * pwmPulseWidth) / 100.0;
 
     setPwmMax(pwmMax);
     
     hardware_PWM = new HardwarePWM(pwmPeriod_us, pwmPulseWidth, pin); 
 }
 
-
-//float PWM::getPwmPeriod(void) { return pwmPeriod_us; }
-//float PWM::getPwmPulseWidth(void) { return pwmPulseWidth; }
-//int PWM::getPwmPulseWidth_us(void) { return pwmPulseWidth_us; }
-void PWM::setPwmMax(int pwmMax) { pwmMax = pwmMax; }
+void PWM::setPwmMax(int pwmMax) 
+{ 
+    pwmMax = pwmMax; 
+}
 
 void PWM::update()
 {

--- a/modules/pwm/pwm.cpp
+++ b/modules/pwm/pwm.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<Module> PWM::create(const JsonObject& config, Remora* instance)
     //const char* comment = config["Comment"];
 
     //printf("\n%s\n",comment);
-    printf("Creating PWM at pin %s\n", pin);
+    printf("\nCreating PWM at pin %s\n", pin);
 
     /*printf("SP[i]: %d\n" // helps with a bit of debugging
        "PWM Max: %d\n"
@@ -42,7 +42,7 @@ std::shared_ptr<Module> PWM::create(const JsonObject& config, Remora* instance)
     }
 
     bool variable_freq = !strcmp(variable, "True");
-    printf("PWM variable_freq = %d\n", variable_freq);
+    //printf("PWM variable_freq = %d\n", variable_freq);
 
     //new_pwm = new PWM(*variable_pointers[period_sp], *variable_pointers[sp], variable_freq, period_us, pwmMax, pin);   
     //new_pwm->setPwmMax(pwmMax);
@@ -61,7 +61,7 @@ PWM::PWM(volatile float &_ptrPwmPeriod, volatile float &_ptrPwmPulseWidth, bool 
     pwmMax(_pwmMax),
     pin(_pin)
 {
-    printf("Creating variable frequency Hardware PWM at pin %s\n", pin.c_str());
+    //printf("Creating variable frequency Hardware PWM at pin %s\n", pin.c_str());
 
     // set initial period and pulse width
     if (variable_freq == true)
@@ -134,7 +134,7 @@ void PWM::recalculate_pulsewidth(void)
         //int capped_pwm = (pwmMax * 100) / PWMMAX;            
         //pwmPulseWidth_us = (pwmPeriod_us * capped_pwm) / 100.0;
         //pwmPulseWidth = capped_pwm;
-        pwmPulseWidth = pwmMax;
+        pwmPulseWidth = ((float)pwmMax / (float)PWMMAX) * 100;
     }
     hardware_PWM->change_pulsewidth(pwmPulseWidth);
 }

--- a/modules/pwm/pwm.h
+++ b/modules/pwm/pwm.h
@@ -1,0 +1,44 @@
+#ifndef PWM_H
+#define PWM_H
+
+#include <string>
+#include <memory>
+
+#include "../../remora.h"
+#include "../../modules/module.h"
+#include "remora-hal/hardware_pwm/hardware_pwm.h"
+
+#define DEFAULT_PWM_PERIOD 100 // 100us
+#define PWMMAX 256
+
+class PWM : public Module
+{
+	private:
+		std::string pin;			        // PWM output pin
+		int pwmMax;					        // maximum PWM output
+
+		HardwarePWM *hardware_PWM;
+
+        volatile float *ptrPwmPeriod; 	    // pointer to the data source
+		volatile float *ptrPwmPulseWidth; 	// pointer to the data source
+
+        float pwmPeriod_us;                      // Period (us)
+        float pwmPulseWidth;                // Pulse width (%)
+        int pwmPulseWidth_us;               // Pulse width (us)
+
+		bool variable_freq;
+
+	public:
+		PWM(volatile float&, volatile float&, bool, int, int, std::string);
+		static std::shared_ptr<Module> create(const JsonObject& config, Remora* instance);
+
+		virtual void update(void);          // Module default interface
+		virtual void slowUpdate(void);      // Module default interface
+
+		void setPwmMax(int);
+		float getPwmPeriod(void);			// getters, primarily for testing
+		float getPwmPulseWidth(void);
+		int getPwmPulseWidth_us(void);
+};
+
+#endif

--- a/modules/pwm/pwm.h
+++ b/modules/pwm/pwm.h
@@ -24,9 +24,10 @@ class PWM : public Module
 
         float pwmPeriod_us;                      // Period (us)
         float pwmPulseWidth;                // Pulse width (%)
-        int pwmPulseWidth_us;               // Pulse width (us)
 
 		bool variable_freq;
+
+		void recalculate_pulsewidth(void);
 
 	public:
 		PWM(volatile float&, volatile float&, bool, int, int, std::string);


### PR DESCRIPTION
Ported in the module from a previous code base and updated to work with Remora-Core

This is the abstract handler for hardware PWM, but not software PWM - potentially could be extended to perform double duty.

For an example of how the hardware layer implementation works on F4 family, see here:
https://github.com/ben-jacobson/Remora-STM32F4xx-PIO/blob/main/Src/remora-hal/hardware_pwm/hardware_pwm.cpp